### PR TITLE
No reencrypt

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -37,7 +37,5 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-sylr.dev/yaml/v3 v3.0.0-20220527083315-54c415adfca1 h1:aCfDffL0TQSFFZ7pISg3vrXPu21Xe/Pf40FLYVz3Nfo=
-sylr.dev/yaml/v3 v3.0.0-20220527083315-54c415adfca1/go.mod h1:4Zku0VUqOuAOvzh8sDnNBOWxgBFIbfHfWtGZI+Qjwx4=
 sylr.dev/yaml/v3 v3.0.0-20220527135632-500fddf2b049 h1:YPPgk82gEmgUGbtTpTokBrnWnpCbHGqzwggHNrOlw40=
 sylr.dev/yaml/v3 v3.0.0-20220527135632-500fddf2b049/go.mod h1:4Zku0VUqOuAOvzh8sDnNBOWxgBFIbfHfWtGZI+Qjwx4=

--- a/wrapper.go
+++ b/wrapper.go
@@ -20,6 +20,8 @@ type Wrapper struct {
 	// DiscardNoTag will not honour NoTag when decrypting so you can re-encrypt
 	// with original tags.
 	DiscardNoTag bool
+	// NoDecrypt will leave encrypted data as-is.
+	NoDecrypt bool
 }
 
 // UnmarshalYAML takes yaml.Node and recursively decrypt data marked with the
@@ -88,7 +90,7 @@ func (w Wrapper) resolve(node *yaml.Node) (*yaml.Node, error) {
 
 	// Check the absence of armored age header and footer
 	valueTrimmed := strings.TrimSpace(node.Value)
-	if !strings.HasPrefix(valueTrimmed, armor.Header) || !strings.HasSuffix(valueTrimmed, armor.Footer) {
+	if w.NoDecrypt || !strings.HasPrefix(valueTrimmed, armor.Header) || !strings.HasSuffix(valueTrimmed, armor.Footer) {
 		return node, nil
 	}
 

--- a/wrapper.go
+++ b/wrapper.go
@@ -36,6 +36,10 @@ func (w Wrapper) UnmarshalYAML(value *yaml.Node) error {
 }
 
 func (w Wrapper) resolve(node *yaml.Node) (*yaml.Node, error) {
+	if node == nil {
+		return nil, nil
+	}
+
 	// Recurse into sequence types
 	if node.Kind == yaml.SequenceNode || node.Kind == yaml.MappingNode {
 		var err error

--- a/wrapper.go
+++ b/wrapper.go
@@ -89,8 +89,7 @@ func (w Wrapper) resolve(node *yaml.Node) (*yaml.Node, error) {
 	}
 
 	// Check the absence of armored age header and footer
-	valueTrimmed := strings.TrimSpace(node.Value)
-	if w.NoDecrypt || !strings.HasPrefix(valueTrimmed, armor.Header) || !strings.HasSuffix(valueTrimmed, armor.Footer) {
+	if w.NoDecrypt || !isArmoredAgeFile(node.Value) {
 		return node, nil
 	}
 

--- a/yaml.go
+++ b/yaml.go
@@ -13,25 +13,24 @@ const (
 	YAMLTag = "!crypto/age"
 )
 
-type marshallerOptions struct {
-	ignoreEncrypted bool
+type marshalYAMLOptions struct {
+	noReencrypt bool
 }
 
 // MarshalYAMLOption is an option for MarshalYAML.
-type MarshalYAMLOption func(*marshallerOptions)
+type MarshalYAMLOption func(*marshalYAMLOptions)
 
 // NoReencrypt tells MarshalYAML to not encrypt values that are already encrypted. It determines this by checking if the
 // value starts with armor.Header ("-----BEGIN AGE ENCRYPTED FILE-----").
 func NoReencrypt() MarshalYAMLOption {
-	return func(m *marshallerOptions) {
-		m.ignoreEncrypted = true
+	return func(m *marshalYAMLOptions) {
+		m.noReencrypt = true
 	}
 }
 
 // MarshalYAML takes a *yaml.Node and []age.Recipient and recursively encrypt/marshal the Values.
 func MarshalYAML(node *yaml.Node, recipients []age.Recipient, options ...MarshalYAMLOption) (*yaml.Node, error) {
-
-	opts := &marshallerOptions{}
+	opts := &marshalYAMLOptions{}
 	for _, o := range options {
 		o(opts)
 	}
@@ -58,7 +57,7 @@ func MarshalYAML(node *yaml.Node, recipients []age.Recipient, options ...Marshal
 		return node, nil
 	}
 
-	if opts.ignoreEncrypted && strings.HasPrefix(strings.TrimSpace(node.Value), armor.Header) {
+	if opts.noReencrypt && strings.HasPrefix(strings.TrimSpace(node.Value), armor.Header) {
 		return node, nil
 	}
 

--- a/yaml.go
+++ b/yaml.go
@@ -20,8 +20,8 @@ type marshallerOptions struct {
 // MarshalYAMLOption is an option for MarshalYAML.
 type MarshalYAMLOption func(*marshallerOptions)
 
-// NoReencrypt tells MarshalYAML to not encrypt tags that are already encrypted. It determines this by checking if the
-// tag starts with armor.Header ("-----BEGIN AGE ENCRYPTED FILE-----").
+// NoReencrypt tells MarshalYAML to not encrypt values that are already encrypted. It determines this by checking if the
+// value starts with armor.Header ("-----BEGIN AGE ENCRYPTED FILE-----").
 func NoReencrypt() MarshalYAMLOption {
 	return func(m *marshallerOptions) {
 		m.ignoreEncrypted = true

--- a/yaml.go
+++ b/yaml.go
@@ -15,32 +15,32 @@ const (
 
 // MarshalYAML takes a *yaml.Node and []age.Recipient and recursively encrypt/marshal the Values.
 func MarshalYAML(node *yaml.Node, recipients []age.Recipient) (*yaml.Node, error) {
-	return Marshaller{
+	return Marshaler{
 		Node:       node,
 		Recipients: recipients,
 	}.marshalYAML()
 }
 
-// Marshaller marshals a *yaml.Node encrypting values with age.
-type Marshaller struct {
+// Marshaler marshals a *yaml.Node encrypting values with age.
+type Marshaler struct {
 	// Node holds the *yaml.Node that will be encrypted with the Recipients. Node must have been decoded with
 	// Wrapper.UnmarshalYAML.
 	// Warning: Node is modified in place.
 	Node *yaml.Node
 	// Recipients that will be used for encrypting.
 	Recipients []age.Recipient
-	// NoReencrypt tells Marshaller to not encrypt values that are already armored age files.
+	// NoReencrypt tells Marshaler to not encrypt values that are already armored age files.
 	NoReencrypt bool
 }
 
 // MarshalYAML implements the yaml.Marshaler interface.
-func (m Marshaller) MarshalYAML() (interface{}, error) {
+func (m Marshaler) MarshalYAML() (interface{}, error) {
 	return m.marshalYAML()
 }
 
 // marshalYAML is the internal implementation of MarshalYAML. We need the internal implementation to be able to return
 // *yaml.Node instead of interface{} because the global MarshalYAML function needs to return *yaml.Node.
-func (m Marshaller) marshalYAML() (*yaml.Node, error) {
+func (m Marshaler) marshalYAML() (*yaml.Node, error) {
 	node := m.Node
 	recipients := m.Recipients
 	if node == nil {
@@ -52,7 +52,7 @@ func (m Marshaller) marshalYAML() (*yaml.Node, error) {
 
 		if len(node.Content) > 0 {
 			for i := range node.Content {
-				node.Content[i], err = Marshaller{
+				node.Content[i], err = Marshaler{
 					Node:        node.Content[i],
 					Recipients:  recipients,
 					NoReencrypt: m.NoReencrypt,

--- a/yaml.go
+++ b/yaml.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"filippo.io/age"
+	"filippo.io/age/armor"
 	"sylr.dev/yaml/v3"
 )
 
@@ -50,14 +51,14 @@ func MarshalYAML(node *yaml.Node, recipients []age.Recipient, options ...Marshal
 		return node, nil
 	}
 
-	if opts.ignoreEncrypted {
-		return node, nil
-	}
-
 	switch {
 	case node.Tag == YAMLTag:
 	case strings.HasPrefix(node.Tag, YAMLTag+":"):
 	default:
+		return node, nil
+	}
+
+	if opts.ignoreEncrypted && strings.HasPrefix(strings.TrimSpace(node.Value), armor.Header) {
 		return node, nil
 	}
 

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -464,7 +464,6 @@ func TestNoRecipientMarshal(t *testing.T) {
 }
 
 func TestNoReencrypt(t *testing.T) {
-	t.Parallel()
 	input := `
 foo: !crypto/age bar
 baz: plain text
@@ -472,9 +471,7 @@ baz: plain text
 	identities, recipients := getKeysFromFiles(t)
 	var node yaml.Node
 
-	//actual := new(bytes.Buffer)
 	decoder := yaml.NewDecoder(bytes.NewBufferString(input))
-	//encoder := yaml.NewEncoder(actual)
 	err := decoder.Decode(&Wrapper{
 		Value: &node,
 	})

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -903,8 +903,7 @@ dup: *passwd`),
 			})
 
 			b, err := yaml.Marshal(&Marshaler{
-				Node:        &node,
-				NoReencrypt: true,
+				node: &node,
 			})
 
 			Convey(fmt.Sprintf("%s (pass #%d): Marshal should not return error", test.Description, i), t, FailureHalts, func() {
@@ -1044,7 +1043,7 @@ baz: plain text
 		t.Fatal(err)
 	}
 	b, err := yaml.Marshal(&Marshaler{
-		Node:       &node,
+		node:       &node,
 		Recipients: recipients,
 	})
 	if err != nil {
@@ -1061,9 +1060,8 @@ baz: plain text
 		t.Fatal(err)
 	}
 	b, err = yaml.Marshal(&Marshaler{
-		Node:        &node,
-		Recipients:  recipients,
-		NoReencrypt: true,
+		node:       &node,
+		Recipients: recipients,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -902,7 +902,7 @@ dup: *passwd`),
 				So(err, ShouldBeNil)
 			})
 
-			b, err := yaml.Marshal(&Marshaller{
+			b, err := yaml.Marshal(&Marshaler{
 				Node:        &node,
 				NoReencrypt: true,
 			})
@@ -1043,7 +1043,7 @@ baz: plain text
 	if err != nil {
 		t.Fatal(err)
 	}
-	b, err := yaml.Marshal(&Marshaller{
+	b, err := yaml.Marshal(&Marshaler{
 		Node:       &node,
 		Recipients: recipients,
 	})
@@ -1060,7 +1060,7 @@ baz: plain text
 	if err != nil {
 		t.Fatal(err)
 	}
-	b, err = yaml.Marshal(&Marshaller{
+	b, err = yaml.Marshal(&Marshaler{
 		Node:        &node,
 		Recipients:  recipients,
 		NoReencrypt: true,

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -51,6 +51,7 @@ func getKeysFromFiles(t *testing.T) ([]age.Identity, []age.Recipient) {
 }
 
 func TestSimpleData(t *testing.T) {
+	t.Parallel()
 	ids, recs := getKeysFromFiles(t)
 
 	// ArmoredStruct based
@@ -96,6 +97,7 @@ func TestSimpleData(t *testing.T) {
 }
 
 func TestAnonymousStruct(t *testing.T) {
+	t.Parallel()
 	ids, _ := getKeysFromFiles(t)
 
 	// Open source yaml
@@ -149,6 +151,7 @@ type complexStruct struct {
 }
 
 func TestComplexData(t *testing.T) {
+	t.Parallel()
 	ids, recs := getKeysFromFiles(t)
 
 	// -- test 1 ---------------------------------------------------------------
@@ -273,6 +276,7 @@ func TestComplexData(t *testing.T) {
 }
 
 func TestUnlmarshallingInputDocument(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		Description string
 		Assertion   func(interface{}, ...interface{}) string
@@ -314,40 +318,44 @@ password: !crypto/age ThisIsMyReallyEncryptedPassword
 	}
 
 	for _, test := range tests {
-		buf := bytes.NewBufferString(test.Input)
-		actual := bytes.NewBuffer(nil)
-		node := yaml.Node{}
+		t.Run(test.Description, func(t *testing.T) {
+			t.Parallel()
+			buf := bytes.NewBufferString(test.Input)
+			actual := bytes.NewBuffer(nil)
+			node := yaml.Node{}
 
-		w := Wrapper{
-			Value:      &node,
-			Identities: []age.Identity{id},
-		}
-		decoder := yaml.NewDecoder(buf)
-		encoder := yaml.NewEncoder(actual)
+			w := Wrapper{
+				Value:      &node,
+				Identities: []age.Identity{id},
+			}
+			decoder := yaml.NewDecoder(buf)
+			encoder := yaml.NewEncoder(actual)
 
-		for {
-			err = decoder.Decode(&w)
-			if err == io.EOF {
-				break
-			} else {
+			for {
+				err = decoder.Decode(&w)
+				if err == io.EOF {
+					break
+				} else {
+					Convey(test.Description, t, func() {
+						So(err, test.Assertion)
+					})
+				}
+
+				err := encoder.Encode(&node)
 				Convey(test.Description, t, func() {
-					So(err, test.Assertion)
+					So(err, ShouldBeNil)
 				})
 			}
 
-			err := encoder.Encode(&node)
 			Convey(test.Description, t, func() {
-				So(err, ShouldBeNil)
+				So(actual.String(), ShouldEqual, test.Expected)
 			})
-		}
-
-		Convey(test.Description, t, func() {
-			So(actual.String(), ShouldEqual, test.Expected)
 		})
 	}
 }
 
 func TestUnlmarshallingBogusEncryptedData(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		Description string
 		Assertion   func(interface{}, ...interface{}) string
@@ -424,23 +432,27 @@ func TestUnlmarshallingBogusEncryptedData(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		buf := bytes.NewBufferString(test.Input)
-		node := yaml.Node{}
+		t.Run(test.Description, func(t *testing.T) {
+			t.Parallel()
+			buf := bytes.NewBufferString(test.Input)
+			node := yaml.Node{}
 
-		w := Wrapper{
-			Value:      &node,
-			Identities: []age.Identity{id},
-		}
-		decoder := yaml.NewDecoder(buf)
-		err = decoder.Decode(&w)
+			w := Wrapper{
+				Value:      &node,
+				Identities: []age.Identity{id},
+			}
+			decoder := yaml.NewDecoder(buf)
+			err = decoder.Decode(&w)
 
-		Convey(test.Description, t, func() {
-			So(err, test.Assertion)
+			Convey(test.Description, t, func() {
+				So(err, test.Assertion)
+			})
 		})
 	}
 }
 
 func TestNoRecipientMarshal(t *testing.T) {
+	t.Parallel()
 	d1 := complexStruct{
 		RegularData: []string{
 			"this is the first pwet",
@@ -463,6 +475,7 @@ func TestNoRecipientMarshal(t *testing.T) {
 }
 
 func TestDecodeEncodeMarshal(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		Description  string
 		Assertion    func(interface{}, ...interface{}) string
@@ -820,110 +833,114 @@ dup: *passwd`),
 	}
 
 	for _, test := range tests {
-		input := test.Input
-		for i := 1; i < 3; i++ {
-			buf := bytes.NewBufferString(input)
-			node := yaml.Node{}
+		t.Run(test.Description, func(t *testing.T) {
+			t.Parallel()
+			input := test.Input
+			for i := 1; i < 3; i++ {
+				buf := bytes.NewBufferString(input)
+				node := yaml.Node{}
 
-			w := Wrapper{
-				Value:        &node,
-				Identities:   []age.Identity{id},
-				DiscardNoTag: test.DiscardNoTag,
+				w := Wrapper{
+					Value:        &node,
+					Identities:   []age.Identity{id},
+					DiscardNoTag: test.DiscardNoTag,
+				}
+
+				actual := new(bytes.Buffer)
+				decoder := yaml.NewDecoder(buf)
+				encoder := yaml.NewEncoder(actual)
+				encoder.SetIndent(2)
+
+				// Load YAML
+				err = decoder.Decode(&w)
+
+				Convey(fmt.Sprintf("%s (pass #%d): Decode should not return error", test.Description, i), t, FailureHalts, func() {
+					So(err, ShouldBeNil)
+				})
+
+				// Marshall decrypted values
+				err = encoder.Encode(&node)
+
+				Convey(fmt.Sprintf("%s (pass #%d): Encode should not return error", test.Description, i), t, FailureHalts, func() {
+					So(err, ShouldBeNil)
+				})
+
+				Convey(fmt.Sprintf("%s (pass #%d): compare outputs", test.Description, i), t, func() {
+					So(actual.String(), test.Assertion, test.Expected)
+				})
+
+				// Marshall encrypted values
+				_, err := MarshalYAML(&node, []age.Recipient{rec})
+
+				Convey(fmt.Sprintf("%s (pass #%d): MarshalYAML should not return error", test.Description, i), t, FailureHalts, func() {
+					So(err, ShouldBeNil)
+				})
+
+				reencoded := new(bytes.Buffer)
+				reencoder := yaml.NewEncoder(reencoded)
+				err = reencoder.Encode(&node)
+
+				Convey(fmt.Sprintf("%s (pass #%d): Re-Encode should not return error", test.Description, i), t, FailureHalts, func() {
+					So(err, ShouldBeNil)
+				})
+
+				input = reencoded.String()
+
+				// try again ignoring encrypted values and make sure we get the same result
+
+				buf = bytes.NewBufferString(input)
+				node = yaml.Node{}
+
+				w = Wrapper{
+					Value:        &node,
+					DiscardNoTag: test.DiscardNoTag,
+					NoDecrypt:    true,
+				}
+
+				actual = new(bytes.Buffer)
+				decoder = yaml.NewDecoder(buf)
+				encoder = yaml.NewEncoder(actual)
+				encoder.SetIndent(2)
+
+				// Load YAML
+				err = decoder.Decode(&w)
+
+				Convey(fmt.Sprintf("%s (pass #%d): Decode should not return error", test.Description, i), t, FailureHalts, func() {
+					So(err, ShouldBeNil)
+				})
+
+				err = encoder.Encode(&node)
+
+				Convey(fmt.Sprintf("%s (pass #%d): Encode should not return error", test.Description, i), t, FailureHalts, func() {
+					So(err, ShouldBeNil)
+				})
+
+				_, err = MarshalYAML(&node, []age.Recipient{rec}, NoReencrypt())
+
+				Convey(fmt.Sprintf("%s (pass #%d): MarshalYAML should not return error", test.Description, i), t, FailureHalts, func() {
+					So(err, ShouldBeNil)
+				})
+
+				reencoded = new(bytes.Buffer)
+				reencoder = yaml.NewEncoder(reencoded)
+				err = reencoder.Encode(&node)
+
+				Convey(fmt.Sprintf("%s (pass #%d): Re-Encode should not return error", test.Description, i), t, FailureHalts, func() {
+					So(err, ShouldBeNil)
+				})
+
+				Convey(fmt.Sprintf("%s (pass #%d): Re-Encode should match original", test.Description, i), t, FailureHalts, func() {
+					So(reencoded.String(), ShouldEqual, input)
+				})
 			}
-
-			actual := new(bytes.Buffer)
-			decoder := yaml.NewDecoder(buf)
-			encoder := yaml.NewEncoder(actual)
-			encoder.SetIndent(2)
-
-			// Load YAML
-			err = decoder.Decode(&w)
-
-			Convey(fmt.Sprintf("%s (pass #%d): Decode should not return error", test.Description, i), t, FailureHalts, func() {
-				So(err, ShouldBeNil)
-			})
-
-			// Marshall decrypted values
-			err = encoder.Encode(&node)
-
-			Convey(fmt.Sprintf("%s (pass #%d): Encode should not return error", test.Description, i), t, FailureHalts, func() {
-				So(err, ShouldBeNil)
-			})
-
-			Convey(fmt.Sprintf("%s (pass #%d): compare outputs", test.Description, i), t, func() {
-				So(actual.String(), test.Assertion, test.Expected)
-			})
-
-			// Marshall encrypted values
-			_, err := MarshalYAML(&node, []age.Recipient{rec})
-
-			Convey(fmt.Sprintf("%s (pass #%d): MarshalYAML should not return error", test.Description, i), t, FailureHalts, func() {
-				So(err, ShouldBeNil)
-			})
-
-			reencoded := new(bytes.Buffer)
-			reencoder := yaml.NewEncoder(reencoded)
-			err = reencoder.Encode(&node)
-
-			Convey(fmt.Sprintf("%s (pass #%d): Re-Encode should not return error", test.Description, i), t, FailureHalts, func() {
-				So(err, ShouldBeNil)
-			})
-
-			input = reencoded.String()
-
-			// try again ignoring encrypted values and make sure we get the same result
-
-			buf = bytes.NewBufferString(input)
-			node = yaml.Node{}
-
-			w = Wrapper{
-				Value:        &node,
-				DiscardNoTag: test.DiscardNoTag,
-				NoDecrypt:    true,
-			}
-
-			actual = new(bytes.Buffer)
-			decoder = yaml.NewDecoder(buf)
-			encoder = yaml.NewEncoder(actual)
-			encoder.SetIndent(2)
-
-			// Load YAML
-			err = decoder.Decode(&w)
-
-			Convey(fmt.Sprintf("%s (pass #%d): Decode should not return error", test.Description, i), t, FailureHalts, func() {
-				So(err, ShouldBeNil)
-			})
-
-			err = encoder.Encode(&node)
-
-			Convey(fmt.Sprintf("%s (pass #%d): Encode should not return error", test.Description, i), t, FailureHalts, func() {
-				So(err, ShouldBeNil)
-			})
-
-			_, err = MarshalYAML(&node, []age.Recipient{rec}, NoReencrypt())
-
-			Convey(fmt.Sprintf("%s (pass #%d): MarshalYAML should not return error", test.Description, i), t, FailureHalts, func() {
-				So(err, ShouldBeNil)
-			})
-
-			reencoded = new(bytes.Buffer)
-			reencoder = yaml.NewEncoder(reencoded)
-			err = reencoder.Encode(&node)
-
-			Convey(fmt.Sprintf("%s (pass #%d): Re-Encode should not return error", test.Description, i), t, FailureHalts, func() {
-				So(err, ShouldBeNil)
-			})
-
-			Convey(fmt.Sprintf("%s (pass #%d): Re-Encode should match original", test.Description, i), t, FailureHalts, func() {
-				So(reencoded.String(), ShouldEqual, input)
-			})
-		}
+		})
 	}
 }
 
 // TestIncorrectBehaviours defines a series of tests that produce known incorrect
 // behaviours that should be fixed
 func TestIncorrectBehaviours(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		Description  string
 		Assertion    func(interface{}, ...interface{}) string
@@ -952,75 +969,78 @@ func TestIncorrectBehaviours(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		input := test.Input
-		for i := 1; i < 3; i++ {
-			buf := bytes.NewBufferString(input)
-			node := yaml.Node{}
+		t.Run(test.Description, func(t *testing.T) {
+			t.Parallel()
+			input := test.Input
+			for i := 1; i < 3; i++ {
+				buf := bytes.NewBufferString(input)
+				node := yaml.Node{}
 
-			w := Wrapper{
-				Value:        &node,
-				Identities:   []age.Identity{id},
-				DiscardNoTag: test.DiscardNoTag,
+				w := Wrapper{
+					Value:        &node,
+					Identities:   []age.Identity{id},
+					DiscardNoTag: test.DiscardNoTag,
+				}
+
+				// Load YAML
+				decoder := yaml.NewDecoder(buf)
+				err = decoder.Decode(&w)
+
+				Convey(fmt.Sprintf("%s (pass #%d): Decode should not return error", test.Description, i), t, FailureHalts, func() {
+					So(err, ShouldBeNil)
+				})
+
+				// Encrypt decrypted values
+				mnode, err := MarshalYAML(&node, []age.Recipient{rec})
+
+				Convey(fmt.Sprintf("%s (pass #%d): Encode should not return error", test.Description, i), t, FailureHalts, func() {
+					So(err, ShouldBeNil)
+				})
+
+				// Marshal
+				actual := new(bytes.Buffer)
+				encoder := yaml.NewEncoder(actual)
+				encoder.SetIndent(2)
+				err = encoder.Encode(mnode)
+
+				Convey(fmt.Sprintf("%s (pass #%d): Encode should not return error", test.Description, i), t, FailureHalts, func() {
+					So(err, ShouldBeNil)
+				})
+
+				// Re-decode
+				rebuf := bytes.NewBuffer(actual.Bytes())
+				renode := yaml.Node{}
+
+				rew := Wrapper{
+					Value:        &renode,
+					Identities:   []age.Identity{id},
+					DiscardNoTag: test.DiscardNoTag,
+				}
+
+				redecoder := yaml.NewDecoder(rebuf)
+				err = redecoder.Decode(&rew)
+
+				Convey(fmt.Sprintf("%s (pass #%d): Re-Encode should not return error", test.Description, i), t, FailureHalts, func() {
+					So(err, ShouldBeNil)
+				})
+
+				// Re-marshal
+				reencoded := new(bytes.Buffer)
+				reencoder := yaml.NewEncoder(reencoded)
+				reencoder.SetIndent(2)
+
+				err = reencoder.Encode(&renode)
+
+				Convey(fmt.Sprintf("%s (pass #%d): Re-Encode should not return error", test.Description, i), t, FailureHalts, func() {
+					So(err, ShouldBeNil)
+				})
+
+				Convey(fmt.Sprintf("%s (pass #%d): compare outputs", test.Description, i), t, func() {
+					So(reencoded.String(), test.Assertion, test.Expected)
+				})
+
+				input = reencoded.String()
 			}
-
-			// Load YAML
-			decoder := yaml.NewDecoder(buf)
-			err = decoder.Decode(&w)
-
-			Convey(fmt.Sprintf("%s (pass #%d): Decode should not return error", test.Description, i), t, FailureHalts, func() {
-				So(err, ShouldBeNil)
-			})
-
-			// Encrypt decrypted values
-			mnode, err := MarshalYAML(&node, []age.Recipient{rec})
-
-			Convey(fmt.Sprintf("%s (pass #%d): Encode should not return error", test.Description, i), t, FailureHalts, func() {
-				So(err, ShouldBeNil)
-			})
-
-			// Marshal
-			actual := new(bytes.Buffer)
-			encoder := yaml.NewEncoder(actual)
-			encoder.SetIndent(2)
-			err = encoder.Encode(mnode)
-
-			Convey(fmt.Sprintf("%s (pass #%d): Encode should not return error", test.Description, i), t, FailureHalts, func() {
-				So(err, ShouldBeNil)
-			})
-
-			// Re-decode
-			rebuf := bytes.NewBuffer(actual.Bytes())
-			renode := yaml.Node{}
-
-			rew := Wrapper{
-				Value:        &renode,
-				Identities:   []age.Identity{id},
-				DiscardNoTag: test.DiscardNoTag,
-			}
-
-			redecoder := yaml.NewDecoder(rebuf)
-			err = redecoder.Decode(&rew)
-
-			Convey(fmt.Sprintf("%s (pass #%d): Re-Encode should not return error", test.Description, i), t, FailureHalts, func() {
-				So(err, ShouldBeNil)
-			})
-
-			// Re-marshal
-			reencoded := new(bytes.Buffer)
-			reencoder := yaml.NewEncoder(reencoded)
-			reencoder.SetIndent(2)
-
-			err = reencoder.Encode(&renode)
-
-			Convey(fmt.Sprintf("%s (pass #%d): Re-Encode should not return error", test.Description, i), t, FailureHalts, func() {
-				So(err, ShouldBeNil)
-			})
-
-			Convey(fmt.Sprintf("%s (pass #%d): compare outputs", test.Description, i), t, func() {
-				So(reencoded.String(), test.Assertion, test.Expected)
-			})
-
-			input = reencoded.String()
-		}
+		})
 	}
 }

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -529,6 +529,9 @@ baz: plain text
 		Value:      &node,
 		Identities: identities,
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	out := new(bytes.Buffer)
 	encoder := yaml.NewEncoder(out)
 	err = encoder.Encode(&node)

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -925,7 +925,7 @@ dup: *passwd`),
 }
 
 // TestIncorrectBehaviours defines a series of tests that produce known incorrect
-// behaviours that should be fixed
+// behaviours that should be fixed.
 func TestIncorrectBehaviours(t *testing.T) {
 	tests := []struct {
 		Description  string
@@ -1004,7 +1004,7 @@ func TestIncorrectBehaviours(t *testing.T) {
 			redecoder := yaml.NewDecoder(rebuf)
 			err = redecoder.Decode(&rew)
 
-			Convey(fmt.Sprintf("%s (pass #%d): Re-Encode should not return error", test.Description, i), t, FailureHalts, func() {
+			Convey(fmt.Sprintf("%s (pass #%d): Re-Decode should not return error", test.Description, i), t, FailureHalts, func() {
 				So(err, ShouldBeNil)
 			})
 
@@ -1039,57 +1039,74 @@ baz: plain text
 	err := yaml.Unmarshal([]byte(input), &Wrapper{
 		Value: &node,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+
+	Convey("Unmarshal should not return error", t, FailureHalts, func() {
+		So(err, ShouldBeNil)
+	})
+
 	b, err := yaml.Marshal(&Marshaler{
 		node:       &node,
 		Recipients: recipients,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+
+	Convey("Marshal should not return error", t, FailureHalts, func() {
+		So(err, ShouldBeNil)
+	})
+
 	decoded := string(b)
 	input = fmt.Sprintf("%s\nqux: !crypto/age quux", b)
 	node = yaml.Node{}
+
 	err = yaml.NewDecoder(strings.NewReader(input)).Decode(&Wrapper{
 		Value:     &node,
 		NoDecrypt: true,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+
+	Convey("NewDecoder should not return error", t, FailureHalts, func() {
+		So(err, ShouldBeNil)
+	})
+
 	b, err = yaml.Marshal(&Marshaler{
 		node:       &node,
 		Recipients: recipients,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.HasPrefix(string(b), decoded) {
-		t.Fatalf("expected %s to start with %s", string(b), decoded)
-	}
+
+	Convey("Marshal should not return error", t, FailureHalts, func() {
+		So(err, ShouldBeNil)
+	})
+
+	Convey("Marshaled data look the same as original", t, FailureHalts, func() {
+		So(string(b), ShouldStartWith, decoded)
+	})
+
 	wantPrefix := "qux: !crypto/age |-\n    -----BEGIN AGE ENCRYPTED FILE-----"
-	if !strings.HasPrefix(strings.TrimPrefix(string(b), decoded), wantPrefix) {
-		t.Fatalf("expected %s to start with %s", strings.TrimPrefix(string(b), decoded), wantPrefix)
-	}
+
+	Convey("Marshaled data should be encrypted", t, FailureHalts, func() {
+		So(strings.TrimPrefix(string(b), decoded), ShouldStartWith, wantPrefix)
+	})
+
 	node = yaml.Node{}
 	err = yaml.Unmarshal(b, &Wrapper{
 		Value:      &node,
 		Identities: identities,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+
+	Convey("Unmarshal should not return error", t, FailureHalts, func() {
+		So(err, ShouldBeNil)
+	})
+
 	b, err = yaml.Marshal(&node)
-	if err != nil {
-		t.Fatal(err)
-	}
+
+	Convey("Marshal should not return error", t, FailureHalts, func() {
+		So(err, ShouldBeNil)
+	})
+
 	want := `foo: !crypto/age bar
 baz: plain text
 qux: !crypto/age quux
 `
-	if string(b) != want {
-		t.Fatalf("expected %s to equal %s", string(b), want)
-	}
+
+	Convey("Marshaled data not as expected", t, FailureHalts, func() {
+		So(string(b), ShouldEqual, want)
+	})
 }


### PR DESCRIPTION
This is the first of two PRs to implement https://github.com/sylr/yage/issues/30.

The two primary changes are:
- Adds `NoDecrypt` to `Wrapper` to prevent encrypted values from being decrypted during decoding.
- Creates `Marshaller` that implements `yaml.Marshaller` and has a `NoReencrypt` option. `NoReencrypt` causes the marshaller to leave alone values that look like armored age files.

This also updates `TestDecodeEncodeMarshal` to run sub tests in parallel which makes them run much quicker for me. Previously `make test` was taking about 30s. Now it takes about 13s. I think it would be much quicker if the tests used X25519 identities instead of Scrypt, but I didn't want to make the diff too big.